### PR TITLE
remove JsProxy as a required thing for polymer elements

### DIFF
--- a/lib/polymer_micro.dart
+++ b/lib/polymer_micro.dart
@@ -14,13 +14,11 @@ import 'src/common/polymer_mixin.dart';
 export 'src/common/polymer_mixin.dart';
 export 'src/common/polymer_register.dart';
 export 'src/common/polymer_serialize.dart';
-import 'src/common/js_proxy.dart';
 export 'src/common/js_proxy.dart';
 export 'src/common/property.dart';
 export 'init.dart' show initPolymer;
 
-class PolymerElement extends HtmlElement
-    with PolymerMixin, PolymerBase, JsProxy {
+class PolymerElement extends HtmlElement with PolymerMixin, PolymerBase {
   PolymerElement.created() : super.created() {
     polymerCreated();
   }

--- a/lib/src/common/polymer_mixin.dart
+++ b/lib/src/common/polymer_mixin.dart
@@ -9,7 +9,8 @@ import 'package:web_components/web_components.dart';
 import 'js_proxy.dart';
 
 /// Basic api for re-using the polymer js prototypes.
-abstract class PolymerMixin implements JsProxy, CustomElementProxyMixin {
+@jsProxyReflectable
+abstract class PolymerMixin implements CustomElementProxyMixin {
   JsObject _proxy;
 
   JsObject get jsElement {
@@ -22,6 +23,4 @@ abstract class PolymerMixin implements JsProxy, CustomElementProxyMixin {
   void polymerCreated() {
     jsElement.callMethod('originalPolymerCreatedCallback');
   }
-
-
 }

--- a/test/src/mini/default_values_test.dart
+++ b/test/src/mini/default_values_test.dart
@@ -18,7 +18,7 @@ main() async {
     element = document.createElement('simple-element');
 
     expect(element.message, 'hello world!');
-    expect(element.jsProxy['message'], 'hello world!');
+    expect(element.jsElement['message'], 'hello world!');
     expect(element.text, contains('hello world!'));
   });
 }


### PR DESCRIPTION
With the new strategy this is no longer required, yay!
