### PR TITLE
add support for static reflectable properties

### DIFF
--- a/lib/src/common/behavior.dart
+++ b/lib/src/common/behavior.dart
@@ -3,25 +3,18 @@
 // BSD-style license that can be found in the LICENSE file.
 library polymer.src.common.behavior;
 
-import 'dart:html';
 import 'dart:js';
+
 import 'package:polymer_interop/polymer_interop.dart' show BehaviorAnnotation;
 export 'package:polymer_interop/polymer_interop.dart'
     show BehaviorAnnotation, BehaviorProxy;
 @GlobalQuantifyMetaCapability(Behavior, jsProxyReflectable)
 import 'package:reflectable/reflectable.dart';
-import 'util.dart';
+
 import 'js_proxy.dart';
+import 'polymer_descriptor.dart';
 
 Map<Type, JsObject> _behaviorsByType = {};
-
-final RegExp _lifecycleMethodsRegex = new RegExp(
-    'created|attached|detached|$_attributeChanged|ready|$_registered|'
-    '$_beforeRegister');
-const String _hostAttributes = 'hostAttributes';
-const String _attributeChanged = 'attributeChanged';
-const String _registered = 'registered';
-const String _beforeRegister = 'beforeRegister';
 
 /// Custom js object containing some helper methods for dart.
 final JsObject _polymerDart = context['Polymer']['Dart'];
@@ -30,46 +23,8 @@ final JsObject _polymerDart = context['Polymer']['Dart'];
 class Behavior implements BehaviorAnnotation {
   JsObject getBehavior(Type type) {
     return _behaviorsByType.putIfAbsent(type, () {
-      var obj = new JsObject(context['Object']);
-      var typeMirror = jsProxyReflectable.reflectType(type);
-
-      var hostAttributes = readHostAttributes(typeMirror);
-      if (hostAttributes != null) {
-        obj[_hostAttributes] = hostAttributes;
-      }
-
-      // Add an entry for each static lifecycle method.
-      typeMirror.staticMembers.forEach((String name, MethodMirror method) {
-        if (!_lifecycleMethodsRegex.hasMatch(name)) return;
-        if (name == _attributeChanged) {
-          obj[name] = new JsFunction.withThis(
-              (thisArg, String attributeName, String oldVal, String newVal) {
-            typeMirror.invoke(
-                name, [convertToDart(thisArg), attributeName, oldVal, newVal]);
-          });
-        } else if (name == _registered || name == _beforeRegister) {
-          // These methods take a single argument which is the JS prototype of
-          // the polymer element which just got registered.
-          obj[name] = _polymerDart.callMethod('invokeDartFactory', [
-                (dartInstance, arguments) {
-              // Dartium hack, the proto has HtmlElement on its proto chain so
-              // it thinks its an HtmlElement.
-              if (dartInstance is HtmlElement) {
-                dartInstance = new JsObject.fromBrowserObject(dartInstance);
-              }
-              var newArgs = [dartInstance]
-                ..addAll(arguments.map((arg) => convertToDart(arg)));
-              typeMirror.invoke(name, newArgs);
-            }
-          ]);
-        } else {
-          // The rest of the methods take a `this` arg as the first argument
-          // which will be an element instance.
-          obj[name] = new JsFunction.withThis((thisArg) {
-            typeMirror.invoke(name, [thisArg]);
-          });
-        }
-      });
+      var obj = createBehaviorDescriptor(type);
+      ClassMirror typeMirror = jsProxyReflectable.reflectType(type);
 
       // Check superinterfaces for additional behaviors.
       var behaviors = [];

--- a/lib/src/common/polymer_descriptor.dart
+++ b/lib/src/common/polymer_descriptor.dart
@@ -5,36 +5,50 @@ library polymer.src.micro.properties;
 
 import 'dart:html';
 import 'dart:js';
+
 import 'package:reflectable/reflectable.dart';
+
 import 'behavior.dart';
 import 'declarations.dart';
 import 'js_proxy.dart';
-import 'property.dart';
-import 'reflectable.dart';
 import 'listen.dart';
 import 'observe.dart';
 import 'polymer_register.dart';
+import 'property.dart';
+import 'reflectable.dart';
 import 'util.dart';
 import '../js/undefined.dart';
 
 /// Creates a javascript object which can be passed to polymer js to register
 /// an element, given a dart [Type] and a [PolymerRegister] annotation.
 JsObject createPolymerDescriptor(Type type, PolymerRegister annotation) {
-  var object = {
-    'is': annotation.tagName,
-    'extends': annotation.extendsTag,
+  return _createDescriptor(type)
+    ..['is'] = annotation.tagName
+    ..['extends'] = annotation.extendsTag
+    ..['__isPolymerDart__'] = true
+    ..['behaviors'] = _buildBehaviorsList(type);
+}
+
+/// Creates a javascript object which can be used as a behavior by polymer js,
+/// given a dart [Type] and a [PolymerRegister] annotation.
+JsObject createBehaviorDescriptor(Type type) {
+  return _createDescriptor(type, true);
+}
+
+/// Shared descriptor between polymer elements and behaviors
+JsObject _createDescriptor(Type type, [bool isBehavior = false]) {
+  var descriptor = new JsObject.jsify({
     'properties': _buildPropertiesObject(type),
     'observers': _buildObserversObject(type),
     'listeners': _buildListenersObject(type),
-    'behaviors': _buildBehaviorsList(type),
-    '__isPolymerDart__': true,
-  };
-  _setupLifecycleMethods(type, object);
-  _setupReflectableMethods(type, object);
-  _setupHostAttributes(type, object);
-  _setupRegistrationMethods(type, object);
+  });
+  _setupLifecycleMethods(type, descriptor, isBehavior);
+  _setupReflectableMethods(type, descriptor);
+  _setupReflectableProperties(type, descriptor);
+  _setupHostAttributes(type, descriptor);
+  _setupRegistrationMethods(type, descriptor);
 
-  return new JsObject.jsify(object);
+  return descriptor;
 }
 
 /// Custom js object containing some helper methods for dart.
@@ -43,7 +57,8 @@ final JsObject _polymerDart = context['Polymer']['Dart'];
 /// Returns a list of [DeclarationMirror]s for all fields annotated as a
 /// [Property].
 Map<String, DeclarationMirror> propertyDeclarationsFor(Type type) {
-  return declarationsFor(type, jsProxyReflectable, where: (name, declaration) {
+  return declarationsFor(type, jsProxyReflectable, includeSuper: false,
+      where: (name, declaration) {
     if (isRegularMethod(declaration) || isSetter(declaration)) return false;
     return declaration.metadata.any((d) => d is Property);
   });
@@ -62,7 +77,8 @@ Map _buildPropertiesObject(Type type) {
 
 /// All @Observe annotated methods.
 Map<String, DeclarationMirror> _observeMethodsFor(Type type) {
-  return declarationsFor(type, jsProxyReflectable, where: (name, declaration) {
+  return declarationsFor(type, jsProxyReflectable, includeSuper: false,
+      where: (name, declaration) {
     if (!isRegularMethod(declaration)) return false;
     return declaration.metadata.any((d) => d is Observe);
   });
@@ -83,7 +99,8 @@ List _buildObserversObject(Type type) {
 
 /// All @Listen annotated methods.
 Map<String, DeclarationMirror> _listenMethodsFor(Type type) {
-  return declarationsFor(type, jsProxyReflectable, where: (name, declaration) {
+  return declarationsFor(type, jsProxyReflectable, includeSuper: false,
+      where: (name, declaration) {
     if (!isRegularMethod(declaration)) return false;
     return declaration.metadata.any((d) => d is Listen);
   });
@@ -105,85 +122,127 @@ Map _buildListenersObject(Type type) {
 const _lifecycleMethods = const [
   'ready',
   'attached',
+  'created',
   'detached',
   'attributeChanged',
-  'serialize',
-  'deserialize'
 ];
 
+const _serializeMethods = const ['serialize', 'deserialize'];
+
 /// All lifecycle methods for a type.
-Map<String, DeclarationMirror> _lifecycleMethodsFor(Type type) {
-  return declarationsFor(type, jsProxyReflectable, where: (name, declaration) {
-    if (!isRegularMethod(declaration)) return false;
-    return _lifecycleMethods.contains(name);
+Map<String, MethodMirror> _lifecycleMethodsFor(Type type) {
+  return declarationsFor(type, jsProxyReflectable, includeSuper: false,
+      where: (name, declaration) {
+    if (declaration is MethodMirror && declaration.isRegularMethod) {
+      return _lifecycleMethods.contains(name) ||
+          _serializeMethods.contains(name);
+    }
+    return false;
   });
 }
 
 /// Set up a proxy for the lifecyle methods, if they exists on the dart class.
-void _setupLifecycleMethods(Type type, Map descriptor) {
+/// If its a behavior we expect most of these
+void _setupLifecycleMethods(Type type, JsObject prototype,
+    [bool isBehavior = false]) {
   var declarations = _lifecycleMethodsFor(type);
-  declarations.forEach((String name, DeclarationMirror declaration) {
-    descriptor[name] = _polymerDart.callMethod('invokeDartFactory', [
+  declarations.forEach((String name, MethodMirror declaration) {
+    if (_lifecycleMethods.contains(name)) {
+      if (!declaration.isStatic && isBehavior) {
+        throw 'Lifecycle methods on behaviors must be static methods, found '
+            '`$name` on `$type`. The first argument to these methods is the'
+            'instance.';
+      } else if (declaration.isStatic && !isBehavior) {
+        throw 'Lifecycle methods on elements must not be static methods, found '
+            '`$name` on class `$type`.';
+      }
+    }
+    prototype[name] = _polymerDart.callMethod('invokeDartFactory', [
       (dartInstance, arguments) {
-        var newArgs = arguments.map((arg) => convertToDart(arg)).toList();
-        var instanceMirror = jsProxyReflectable.reflect(dartInstance);
-        return instanceMirror.invoke(name, newArgs);
+        var newArgs = [];
+        var mirror;
+        if (declaration.isStatic) {
+          mirror = jsProxyReflectable.reflectType(type);
+          newArgs.add(dartInstance);
+        } else {
+          mirror = jsProxyReflectable.reflect(dartInstance);
+        }
+        newArgs.addAll(arguments.map((arg) => convertToDart(arg)));
+        return mirror.invoke(name, newArgs);
       }
     ]);
   });
 }
 
 /// All methods annotated with @reflectable.
-Map<String, DeclarationMirror> _reflectableMethodsFor(Type type) {
-  return declarationsFor(type, jsProxyReflectable, where: (name, declaration) {
-    if (!isRegularMethod(declaration)) return false;
-    return declaration.metadata.any((d) => d is PolymerReflectable);
+Map<String, MethodMirror> _reflectableMethodsFor(Type type) {
+  return declarationsFor(type, jsProxyReflectable, includeSuper: false,
+      where: (name, declaration) {
+    if (declaration is MethodMirror && declaration.isRegularMethod) {
+      return declaration.metadata.any((d) => d is PolymerReflectable);
+    }
+    return false;
   });
 }
 
 /// Set up a proxy for any method with an @reflectable annotation.
-void _setupReflectableMethods(Type type, Map descriptor) {
+void _setupReflectableMethods(Type type, JsObject prototype) {
   var declarations = _reflectableMethodsFor(type);
-  declarations.forEach((String name, DeclarationMirror declaration) {
+  declarations.forEach((String name, MethodMirror declaration) {
     // Error on anything in `_registrationMethods`.
     if (_registrationMethods.contains(name)) {
+      if (declaration.isStatic) return;
       throw 'Disallowed instance method `$name` with @reflectable annotation '
-        'on the `${declaration.owner.simpleName}` class, since it has a '
-        'special meaning in Polymer. You can either rename the method or'
-        'change it to a static method. If it is a static method it will be '
-        'invoked with the JS prototype of the element at registration time.';
+          'on the `${declaration.owner.simpleName}` class, since it has a '
+          'special meaning in Polymer. You can either rename the method or'
+          'change it to a static method. If it is a static method it will be '
+          'invoked with the JS prototype of the element at registration time.';
     }
 
     // Add the method.
-    descriptor[name] = _polymerDart.callMethod('invokeDartFactory', [
-      (dartInstance, arguments) {
-        var newArgs = arguments.map((arg) => convertToDart(arg)).toList();
-        var instanceMirror = jsProxyReflectable.reflect(dartInstance);
-        return instanceMirror.invoke(name, newArgs);
-      }
-    ]);
+    addDeclarationToPrototype(name, type, declaration, prototype);
   });
 }
 
-/// Add the hostAttributes property to the descriptor if it exists.
-void _setupHostAttributes(Type type, Map descriptor) {
+/// All properties annotated with a [Reflectable] but not a [Property] since
+/// those are handled separately.
+Map<String, DeclarationMirror> _reflectablePropertiesFor(Type type) {
+  return declarationsFor(type, jsProxyReflectable, includeSuper: false,
+      where: (name, declaration) {
+    if (declaration is MethodMirror && declaration.isRegularMethod) {
+      return false;
+    }
+    return declaration.metadata
+        .any((d) => d is PolymerReflectable && d is! Property);
+  });
+}
+
+/// Set up all @reflectable properties (that aren't marked with @property)
+void _setupReflectableProperties(Type type, JsObject prototype) {
+  var declarations = _reflectablePropertiesFor(type);
+  declarations.forEach((name, declaration) =>
+      addDeclarationToPrototype(name, type, declaration, prototype));
+}
+
+/// Add the hostAttributes property to the prototype if it exists.
+void _setupHostAttributes(Type type, JsObject prototype) {
   var typeMirror = jsProxyReflectable.reflectType(type);
   var hostAttributes = readHostAttributes(typeMirror);
   if (hostAttributes != null) {
-    descriptor['hostAttributes'] = hostAttributes;
+    prototype['hostAttributes'] = hostAttributes;
   }
 }
 
 final _registrationMethods = const ['registered', 'beforeRegister'];
 
 /// Sets up any static methods contained in `_staticRegistrationMethods`.
-void _setupRegistrationMethods(Type type, Map descriptor) {
+void _setupRegistrationMethods(Type type, JsObject prototype) {
   var typeMirror = jsProxyReflectable.reflectType(type);
   for (String name in _registrationMethods) {
     var method = typeMirror.staticMembers[name];
     if (method == null || method is! MethodMirror) continue;
-    descriptor[name] = _polymerDart.callMethod('invokeDartFactory', [
-          (dartInstance, arguments) {
+    prototype[name] = _polymerDart.callMethod('invokeDartFactory', [
+      (dartInstance, arguments) {
         // Dartium hack, the proto has HtmlElement on its proto chain so
         // it thinks its an HtmlElement.
         if (dartInstance is HtmlElement) {

--- a/lib/src/common/polymer_descriptor.dart
+++ b/lib/src/common/polymer_descriptor.dart
@@ -308,7 +308,7 @@ bool _isBehavior(instance) => instance is BehaviorAnnotation;
 bool _hasBehaviorMeta(ClassMirror clazz) => clazz.metadata.any(_isBehavior);
 
 /// List of [JsObjects]s representing the behaviors for an element.
-Iterable<JsObject> _buildBehaviorsList(Type type) {
+JsArray<JsObject> _buildBehaviorsList(Type type) {
   // All behavior mixins, in order.
   var allBehaviors =
       mixinsFor(type, jsProxyReflectable).where(_hasBehaviorMeta);
@@ -328,7 +328,7 @@ Iterable<JsObject> _buildBehaviorsList(Type type) {
     behaviorStack.add(behavior);
   }
 
-  return <JsObject>[_polymerDart['InteropBehavior']]
+  return new JsArray<JsObject>.from([_polymerDart['InteropBehavior']]
     ..addAll(behaviorStack.map((ClassMirror behavior) {
       BehaviorAnnotation meta = behavior.metadata.firstWhere(_isBehavior);
       if (!behavior.hasBestEffortReflectedType) {
@@ -336,7 +336,7 @@ Iterable<JsObject> _buildBehaviorsList(Type type) {
             '${behavior.simpleName}.';
       }
       return meta.getBehavior(behavior.bestEffortReflectedType);
-    }));
+    })));
 }
 
 // Throws an error about expected mixins that must precede the [clazz] mixin.

--- a/test/src/common/behavior_test.html
+++ b/test/src/common/behavior_test.html
@@ -8,8 +8,8 @@ BSD-style license that can be found in the LICENSE file.
 <head>
   <script src="packages/web_components/webcomponents-lite.min.js"></script>
   <link rel="x-dart-test" href="behavior_test.dart">
-  <!--<script type="application/dart" src="behavior_test.dart"></script>-->
-  <!--<script src="packages/browser/dart.js"></script>-->
+  <!-- <script type="application/dart" src="behavior_test.dart"></script> -->
+  <!-- <script src="packages/browser/dart.js"></script> -->
   <script src="packages/test/dart.js"></script>
 </head>
 <body>

--- a/test/src/common/polymer_descriptor_test.html
+++ b/test/src/common/polymer_descriptor_test.html
@@ -8,8 +8,8 @@ BSD-style license that can be found in the LICENSE file.
 <head>
   <script src="packages/web_components/webcomponents-lite.min.js"></script>
   <link rel="x-dart-test" href="polymer_descriptor_test.dart">
-  <!--<script type="application/dart" src="polymer_descriptor_test.dart"></script>-->
-  <!--<script src="packages/browser/dart.js"></script>-->
+  <!-- <script type="application/dart" src="polymer_descriptor_test.dart"></script> -->
+  <!-- <script src="packages/browser/dart.js"></script> -->
   <script src="packages/test/dart.js"></script>
 </head>
 <body>

--- a/test/src/mini/bottom_up_ready_test.dart
+++ b/test/src/mini/bottom_up_ready_test.dart
@@ -4,7 +4,6 @@
 @TestOn('browser')
 library polymer.test.src.mini.bottom_up_ready_test;
 
-import 'dart:async';
 import 'dart:html';
 import 'package:test/test.dart';
 import 'package:polymer/polymer_mini.dart';
@@ -21,28 +20,27 @@ main() async {
   });
 }
 
+@behavior
+class ReadyRecorder {
+  static int _readiesSeen = 0;
+  int readyOrder;
+
+  static ready(ReadyRecorder instance) {
+    instance.readyOrder = _readiesSeen++;
+  }
+}
+
 @PolymerRegister('parent-element')
-class ParentElement extends ReadyRecordingElement {
+class ParentElement extends PolymerElement with ReadyRecorder {
   ParentElement.created() : super.created();
 }
 
 @PolymerRegister('child-element')
-class ChildElement extends ReadyRecordingElement {
+class ChildElement extends PolymerElement with ReadyRecorder {
   ChildElement.created() : super.created();
 }
 
 @PolymerRegister('grandchild-element')
-class GrandchildElement extends ReadyRecordingElement {
+class GrandchildElement extends PolymerElement with ReadyRecorder {
   GrandchildElement.created() : super.created();
-}
-
-class ReadyRecordingElement extends PolymerElement {
-  static int _readiesSeen = 0;
-  int readyOrder;
-
-  ReadyRecordingElement.created() : super.created();
-
-  ready() {
-    readyOrder = _readiesSeen++;
-  }
 }


### PR DESCRIPTION
Also moved properties/listeners/observers for behaviors to their js descriptor objects. This lines up with javascript semantics more closely. It also means `@property`, `@Observe`, `@listen`, etc are only supported for classes with an `@behavior` annotation.

closes https://github.com/dart-lang/polymer-dart/issues/676
