### PR TITLE
updated tests for newer `polymer_interop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 1.0.0-rc.18
+  * Update tests because of `notifyPath` signature change
+
 #### 1.0.0-rc.17
   * Update reflectable version to allow latest.
   * Fixed some analyzer hints.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: polymer
-version: 1.0.0-rc.17
+version: 1.0.0-rc.18
 author: Polymer.dart Authors <web-ui-dev@dartlang.org>
 description: >
   Polymer.dart is a new type of library for the web, built on top of Web

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   html: ^0.12.0
   initialize: '>=0.5.1+3 <0.7.0'
   path: ^1.3.0
-  polymer_interop: ^1.0.0-rc.9
+  polymer_interop: ^1.0.0-rc.10
   reflectable: '^0.5.0'
   web_components: '>=0.11.3 <0.13.0'
 dev_dependencies:

--- a/test/src/common/polymer_mixin_test.dart
+++ b/test/src/common/polymer_mixin_test.dart
@@ -325,7 +325,7 @@ class Thing extends JsProxy {
 
   Thing(this.field);
 
-  bool operator ==(Thing other) => other.field == this.field;
+  bool operator ==(var other) => other is Thing && (other.field == this.field);
 
   int get hashCode => field.hashCode;
 }

--- a/test/src/template/templatizer_test.dart
+++ b/test/src/template/templatizer_test.dart
@@ -165,7 +165,7 @@ class UserListElement extends PolymerElement with Templatizer {
       instance.notifyPath(
           (['user']..addAll(parts.getRange(2, parts.length))).join('.'),
           get(path),
-          fromAbove: true);
+          true);
     }
   }
 }


### PR DESCRIPTION
`notifyPath` signature changes affects only two tests.